### PR TITLE
fix navbar transparent background on full scroll

### DIFF
--- a/_sass/_sliding-menu.scss
+++ b/_sass/_sliding-menu.scss
@@ -217,7 +217,7 @@
     top: 0;
     right: 0;
     width: 100%;
-    height: 100%;
+    height: 140%;
     transform: scaleX(0);
     transform-origin: center right;
     background: #181818;


### PR DESCRIPTION
Fixed a bug that would occur when you perform a full scroll on the navbar panel. Left a transparent strip of background at the bottom.